### PR TITLE
fix(ci-cd): use token-bureau

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -2,14 +2,23 @@ name: 🐙 Github Release
 
 on: push
 
+permissions:
+  id-token: write  # Required for OIDC token generation
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: http://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
       - name: Checkout
         uses: actions/checkout@v4
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,17 +11,25 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write  # Required for OIDC token generation
 
 jobs:
   tag-and-changelog:
     if:  github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Get GitHub App Token
+        id: token
+        uses: SocialGouv/token-bureau@main
+        with:
+          token-bureau-url: http://token-bureau.fabrique.social.gouv.fr
+          audience: socialgouv
+
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+          token: ${{ steps.token.outputs.token }}
 
       - name: Set up Go
         uses: actions/setup-go@v4


### PR DESCRIPTION
Migration vers le nouveau système "TokenBureau", le SOCIALGROOVYBOT_BOTO_PAT ne sera plus disponible à partir de février 2025, si vous voulez que vos workflows continuent à fonctionner correctement, vous devez merger cette PR.